### PR TITLE
set SYSTEM_TYPE and SYSTEM_FAMILY for zaius

### DIFF
--- a/zaius.xml
+++ b/zaius.xml
@@ -4507,7 +4507,7 @@
 	</attribute>
 	<attribute>
 		<id>SYSTEM_FAMILY</id>
-		<default>ibm,p9</default>
+		<default>ingrasys,p9</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_IPL_PHASE</id>
@@ -4535,7 +4535,7 @@
 	</attribute>
 	<attribute>
 		<id>SYSTEM_TYPE</id>
-		<default>ibm,miscopenpower</default>
+		<default>ingrasys,zaius</default>
 	</attribute>
 	<attribute>
 		<id>SYSTEM_WOF_ENABLED</id>


### PR DESCRIPTION
Both of these are turned into the compatible strings for the device-tree
root node and are used by skiboot (and Linux) to identify the platform
they are running on. As a result they need to be well chosen.

I only picked "ingrasys,zaius" and "ingrasys,p9" since they're similar to the barreleye compatible string "ingrasys,barreleye". Feel free to use something else.