### PR TITLE
zaius-xml: update DIMM connector numbering to match DVT board

### DIFF
--- a/zaius.xml
+++ b/zaius.xml
@@ -2380,7 +2380,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0</id>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-16</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
 	<value></value>
@@ -2391,7 +2391,7 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0</id>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-16/dimm-0</id>
 	<property>
 	<id>FRU_NAME</id>
 	<value></value>
@@ -2400,182 +2400,6 @@
 	<id>IPMI_INSTANCE</id>
 	<value></value>
 	</property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-4/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-5/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-6/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-7/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-8/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-9/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
-</globalSetting>
-<globalSetting>
-        <id>/sys-0/node-0/motherboard-0/dimmconn-16/dimm-0</id>
-        <property>
-        <id>FRU_NAME</id>
-        <value></value>
-        </property>
-        <property>
-        <id>IPMI_INSTANCE</id>
-        <value></value>
-        </property>
 </globalSetting>
 <globalSetting>
         <id>/sys-0/node-0/motherboard-0/dimmconn-17/dimm-0</id>
@@ -2623,6 +2447,28 @@
 </globalSetting>
 <globalSetting>
         <id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0</id>
         <property>
         <id>FRU_NAME</id>
         <value></value>
@@ -2720,639 +2566,172 @@
         <value></value>
         </property>
 </globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-4/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-5/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-8/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-9/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
+<globalSetting>
+        <id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0</id>
+        <property>
+        <id>FRU_NAME</id>
+        <value></value>
+        </property>
+        <property>
+        <id>IPMI_INSTANCE</id>
+        <value></value>
+        </property>
+</globalSetting>
 
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm-thermal-sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x38</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC1</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC0</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/spd</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA8</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3A</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC3</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC2</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAA</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x30</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD5</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD4</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/spd</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA0</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x32</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD7</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD6</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA2</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x32</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD9</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xD8</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA2</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x30</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDB</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDA</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA0</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3A</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDD</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDC</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAA</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm-thermal-sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x38</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDF</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xDE</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA8</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-16</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
 <globalSetting>
 	<id>/sys-0/node-0/motherboard-0/dimmconn-16/dimm-0/ddr4</id>
 	<property>
 	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-16/dimm-0/dimm-thermal-sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
 	<value></value>
 	</property>
 </globalSetting>
@@ -3364,7 +2743,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x34</value>
+	<value>0x38</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -3383,7 +2762,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xE1</value>
+	<value>0xC1</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -3394,7 +2773,14 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xE0</value>
+	<value>0xC0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-16/dimm-0/spd</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -3405,7 +2791,11 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA4</value>
+	<value>0xA8</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -3438,7 +2828,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x36</value>
+	<value>0x3A</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -3457,7 +2847,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xE3</value>
+	<value>0xC3</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -3468,7 +2858,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xE2</value>
+	<value>0xC2</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -3479,717 +2869,11 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA6</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
+	<value>0xAA</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
 	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3C</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE5</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE4</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAC</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3E</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE7</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE6</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAE</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x30</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC5</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC4</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/spd</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA0</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x36</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE9</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xE8</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA6</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x34</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xEB</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xEA</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA4</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0</id>
-	<property>
-	<id>FRU_NAME</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3E</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xED</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xEC</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAE</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0</id>
-	<property>
-	<id>FRU_NAME</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x3C</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xEF</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xEE</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xAC</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x34</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xF1</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xF0</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/spd</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA4</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x36</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xF3</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xF2</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA6</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4222,7 +2906,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3C</value>
+	<value>0x30</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4241,7 +2925,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF5</value>
+	<value>0xD5</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4252,7 +2936,14 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF4</value>
+	<value>0xD4</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-26/dimm-0/spd</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4263,7 +2954,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xAC</value>
+	<value>0xA0</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4296,7 +2987,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3E</value>
+	<value>0x32</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4315,7 +3006,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF7</value>
+	<value>0xD7</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4326,7 +3017,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF6</value>
+	<value>0xD6</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4337,7 +3028,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xAE</value>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4370,7 +3061,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x36</value>
+	<value>0x32</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4389,7 +3080,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF9</value>
+	<value>0xD9</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4400,7 +3091,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xF8</value>
+	<value>0xD8</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4411,7 +3102,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA6</value>
+	<value>0xA2</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4444,7 +3135,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x34</value>
+	<value>0x30</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4463,7 +3154,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xFB</value>
+	<value>0xDB</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4474,7 +3165,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xFA</value>
+	<value>0xDA</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4485,85 +3176,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA4</value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3</id>
-	<property>
-	<id>CONNECTOR_TYPE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/ddr4</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0x32</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>VPD_SIZE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm_func_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC7</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm_temp_sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-	<property>
-	<id>IPMI_SENSOR_ID</id>
-	<value>0xC6</value>
-	</property>
-</globalSetting>
-<globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/spd/i2c-slave</id>
-	<property>
-	<id>DIRECTION</id>
-	<value></value>
-	</property>
-	<property>
-	<id>I2C_ADDRESS</id>
-	<value>0xA2</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
+	<value>0xA0</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4596,7 +3209,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3E</value>
+	<value>0x3A</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4615,7 +3228,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xFD</value>
+	<value>0xDD</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4626,7 +3239,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xFC</value>
+	<value>0xDC</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4637,7 +3250,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xAE</value>
+	<value>0xAA</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4663,6 +3276,13 @@
 	</property>
 </globalSetting>
 <globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-31/dimm-0/dimm-thermal-sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
 	<id>/sys-0/node-0/motherboard-0/dimmconn-31/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
 	<property>
 	<id>DIRECTION</id>
@@ -4670,7 +3290,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3E</value>
+	<value>0x38</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4689,7 +3309,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xBF</value>
+	<value>0xDF</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4700,7 +3320,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xFE</value>
+	<value>0xDE</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4711,7 +3331,388 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
+	<value>0xA8</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE1</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-0/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA4</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x36</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE3</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE2</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-1/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA6</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3C</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE5</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE4</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-2/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
 	<value>0xAC</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3E</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE7</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xE6</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-3/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAE</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x30</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC5</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC4</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/spd</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-18/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA0</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4744,7 +3745,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x32</value>
+	<value>0x36</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4763,7 +3764,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xC9</value>
+	<value>0xE9</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4774,7 +3775,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xC8</value>
+	<value>0xE8</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4785,11 +3786,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA2</value>
-	</property>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
+	<value>0xA6</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4822,7 +3819,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x30</value>
+	<value>0x34</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4841,7 +3838,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCB</value>
+	<value>0xEB</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4852,7 +3849,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCA</value>
+	<value>0xEA</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4863,7 +3860,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA0</value>
+	<value>0xA4</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4874,6 +3871,17 @@
 	<id>/sys-0/node-0/motherboard-0/dimmconn-6</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-6/dimm-0</id>
+	<property>
+	<id>FRU_NAME</id>
 	<value></value>
 	</property>
 	<property>
@@ -4896,7 +3904,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3A</value>
+	<value>0x3E</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4915,7 +3923,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCD</value>
+	<value>0xED</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4926,7 +3934,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCC</value>
+	<value>0xEC</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -4937,7 +3945,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xAA</value>
+	<value>0xAE</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -4948,6 +3956,17 @@
 	<id>/sys-0/node-0/motherboard-0/dimmconn-7</id>
 	<property>
 	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-7/dimm-0</id>
+	<property>
+	<id>FRU_NAME</id>
 	<value></value>
 	</property>
 	<property>
@@ -4970,7 +3989,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x38</value>
+	<value>0x3C</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -4989,7 +4008,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCF</value>
+	<value>0xEF</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -5000,7 +4019,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xCE</value>
+	<value>0xEE</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -5011,7 +4030,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA8</value>
+	<value>0xAC</value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -5044,7 +4063,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x38</value>
+	<value>0x34</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -5063,7 +4082,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xD1</value>
+	<value>0xF1</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -5074,7 +4093,14 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xD0</value>
+	<value>0xF0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-8/dimm-0/spd</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -5085,7 +4111,11 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0xA8</value>
+	<value>0xA4</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
 	</property>
 	<property>
 	<id>VPD_SIZE</id>
@@ -5111,13 +4141,6 @@
 	</property>
 </globalSetting>
 <globalSetting>
-	<id>/sys-0/node-0/motherboard-0/dimmconn-9/dimm-0/dimm-thermal-sensor</id>
-	<property>
-	<id>IPMI_INSTANCE</id>
-	<value></value>
-	</property>
-</globalSetting>
-<globalSetting>
 	<id>/sys-0/node-0/motherboard-0/dimmconn-9/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
 	<property>
 	<id>DIRECTION</id>
@@ -5125,7 +4148,7 @@
 	</property>
 	<property>
 	<id>I2C_ADDRESS</id>
-	<value>0x3A</value>
+	<value>0x36</value>
 	</property>
 	<property>
 	<id>IPMI_INSTANCE</id>
@@ -5144,7 +4167,7 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xD3</value>
+	<value>0xF3</value>
 	</property>
 </globalSetting>
 <globalSetting>
@@ -5155,11 +4178,988 @@
 	</property>
 	<property>
 	<id>IPMI_SENSOR_ID</id>
-	<value>0xD2</value>
+	<value>0xF2</value>
 	</property>
 </globalSetting>
 <globalSetting>
 	<id>/sys-0/node-0/motherboard-0/dimmconn-9/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA6</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3C</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF5</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF4</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-10/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAC</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3E</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF7</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF6</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-11/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAE</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x36</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF9</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xF8</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-12/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA6</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x34</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xFB</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xFA</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-13/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA4</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x32</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC7</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC6</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-19/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3E</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xFD</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xFC</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-14/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAE</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3E</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xBF</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xFE</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-15/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAC</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x32</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC9</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xC8</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-20/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA2</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x30</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCB</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCA</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-21/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA0</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3A</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCD</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCC</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-22/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xAA</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x38</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCF</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xCE</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-23/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA8</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x38</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xD1</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xD0</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-24/dimm-0/spd/i2c-slave</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0xA8</value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25</id>
+	<property>
+	<id>CONNECTOR_TYPE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/ddr4</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm-thermal-sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</id>
+	<property>
+	<id>DIRECTION</id>
+	<value></value>
+	</property>
+	<property>
+	<id>I2C_ADDRESS</id>
+	<value>0x3A</value>
+	</property>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>VPD_SIZE</id>
+	<value></value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm_func_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xD3</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/dimm_temp_sensor</id>
+	<property>
+	<id>IPMI_INSTANCE</id>
+	<value></value>
+	</property>
+	<property>
+	<id>IPMI_SENSOR_ID</id>
+	<value>0xD2</value>
+	</property>
+</globalSetting>
+<globalSetting>
+	<id>/sys-0/node-0/motherboard-0/dimmconn-25/dimm-0/spd/i2c-slave</id>
 	<property>
 	<id>DIRECTION</id>
 	<value></value>
@@ -9999,22 +9999,6 @@
 	<child_id>proc_socket-0</child_id>
 	<child_id>proc_socket-1</child_id>
 	<child_id>bmc-0</child_id>
-	<child_id>dimmconn-0</child_id>
-	<child_id>dimmconn-1</child_id>
-	<child_id>dimmconn-2</child_id>
-	<child_id>dimmconn-3</child_id>
-	<child_id>dimmconn-4</child_id>
-	<child_id>dimmconn-5</child_id>
-	<child_id>dimmconn-6</child_id>
-	<child_id>dimmconn-7</child_id>
-	<child_id>dimmconn-8</child_id>
-	<child_id>dimmconn-9</child_id>
-	<child_id>dimmconn-10</child_id>
-	<child_id>dimmconn-11</child_id>
-	<child_id>dimmconn-12</child_id>
-	<child_id>dimmconn-13</child_id>
-	<child_id>dimmconn-14</child_id>
-	<child_id>dimmconn-15</child_id>
 	<child_id>dimmconn-16</child_id>
 	<child_id>dimmconn-17</child_id>
 	<child_id>dimmconn-18</child_id>
@@ -10031,6 +10015,22 @@
 	<child_id>dimmconn-29</child_id>
 	<child_id>dimmconn-30</child_id>
 	<child_id>dimmconn-31</child_id>
+	<child_id>dimmconn-0</child_id>
+	<child_id>dimmconn-1</child_id>
+	<child_id>dimmconn-2</child_id>
+	<child_id>dimmconn-3</child_id>
+	<child_id>dimmconn-4</child_id>
+	<child_id>dimmconn-5</child_id>
+	<child_id>dimmconn-6</child_id>
+	<child_id>dimmconn-7</child_id>
+	<child_id>dimmconn-8</child_id>
+	<child_id>dimmconn-9</child_id>
+	<child_id>dimmconn-10</child_id>
+	<child_id>dimmconn-11</child_id>
+	<child_id>dimmconn-12</child_id>
+	<child_id>dimmconn-13</child_id>
+	<child_id>dimmconn-14</child_id>
+	<child_id>dimmconn-15</child_id>
 	<child_id>pcieslot-0</child_id>
 	<child_id>pcieslot-1</child_id>
 	<child_id>pcieslot-2</child_id>
@@ -10149,219 +10149,11 @@
 		<default>NA</default>
 	</attribute>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs0 => dimmconn-0/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs0 => dimmconn-16/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
 		<source_target>ddr_ch6:cs0</source_target>
-		<dest_path>dimmconn-0/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs1 => dimmconn-1/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
-		<source_target>ddr_ch6:cs1</source_target>
-		<dest_path>dimmconn-1/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs0 => dimmconn-2/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
-		<source_target>ddr_ch4:cs0</source_target>
-		<dest_path>dimmconn-2/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs1 => dimmconn-3/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
-		<source_target>ddr_ch4:cs1</source_target>
-		<dest_path>dimmconn-3/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs1 => dimmconn-4/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
-		<source_target>ddr_ch0:cs1</source_target>
-		<dest_path>dimmconn-4/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs0 => dimmconn-5/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
-		<source_target>ddr_ch0:cs0</source_target>
-		<dest_path>dimmconn-5/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs1 => dimmconn-6/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
-		<source_target>ddr_ch2:cs1</source_target>
-		<dest_path>dimmconn-6/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs0 => dimmconn-7/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
-		<source_target>ddr_ch2:cs0</source_target>
-		<dest_path>dimmconn-7/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs0 => dimmconn-8/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
-		<source_target>ddr_ch6:cs0</source_target>
-		<dest_path>dimmconn-8/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs1 => dimmconn-9/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
-		<source_target>ddr_ch6:cs1</source_target>
-		<dest_path>dimmconn-9/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs0 => dimmconn-10/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
-		<source_target>ddr_ch4:cs0</source_target>
-		<dest_path>dimmconn-10/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs1 => dimmconn-11/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
-		<source_target>ddr_ch4:cs1</source_target>
-		<dest_path>dimmconn-11/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs1 => dimmconn-12/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
-		<source_target>ddr_ch0:cs1</source_target>
-		<dest_path>dimmconn-12/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs0 => dimmconn-13/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
-		<source_target>ddr_ch0:cs0</source_target>
-		<dest_path>dimmconn-13/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs1 => dimmconn-14/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
-		<source_target>ddr_ch2:cs1</source_target>
-		<dest_path>dimmconn-14/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs0 => dimmconn-15/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
-		<source_target>ddr_ch2:cs0</source_target>
-		<dest_path>dimmconn-15/dimm-0/</dest_path>
-		<dest_target>ddr4</dest_target>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs0 => dimmconn-16/dimm-0/ddr4</bus_id>
-		<bus_type>DDR4</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
-		<source_target>ddr_ch5:cs0</source_target>
 		<dest_path>dimmconn-16/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10370,11 +10162,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs1 => dimmconn-17/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs1 => dimmconn-17/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
-		<source_target>ddr_ch5:cs1</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
+		<source_target>ddr_ch6:cs1</source_target>
 		<dest_path>dimmconn-17/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10383,11 +10175,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs0 => dimmconn-18/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs0 => dimmconn-18/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
-		<source_target>ddr_ch7:cs0</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
+		<source_target>ddr_ch4:cs0</source_target>
 		<dest_path>dimmconn-18/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10396,11 +10188,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs1 => dimmconn-19/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs1 => dimmconn-19/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
-		<source_target>ddr_ch7:cs1</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
+		<source_target>ddr_ch4:cs1</source_target>
 		<dest_path>dimmconn-19/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10409,11 +10201,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs1 => dimmconn-20/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs1 => dimmconn-20/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
-		<source_target>ddr_ch1:cs1</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
+		<source_target>ddr_ch0:cs1</source_target>
 		<dest_path>dimmconn-20/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10422,11 +10214,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs0 => dimmconn-21/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs0 => dimmconn-21/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
-		<source_target>ddr_ch1:cs0</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
+		<source_target>ddr_ch0:cs0</source_target>
 		<dest_path>dimmconn-21/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10435,11 +10227,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs1 => dimmconn-22/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs1 => dimmconn-22/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
-		<source_target>ddr_ch3:cs1</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
+		<source_target>ddr_ch2:cs1</source_target>
 		<dest_path>dimmconn-22/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10448,11 +10240,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs0 => dimmconn-23/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs0 => dimmconn-23/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
-		<source_target>ddr_ch3:cs0</source_target>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
+		<source_target>ddr_ch2:cs0</source_target>
 		<dest_path>dimmconn-23/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10461,11 +10253,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs0 => dimmconn-24/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs0 => dimmconn-24/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
-		<source_target>ddr_ch5:cs0</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
+		<source_target>ddr_ch6:cs0</source_target>
 		<dest_path>dimmconn-24/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10474,11 +10266,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs1 => dimmconn-25/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/ddr_ch6:cs1 => dimmconn-25/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
-		<source_target>ddr_ch5:cs1</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca6/</source_path>
+		<source_target>ddr_ch6:cs1</source_target>
 		<dest_path>dimmconn-25/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10487,11 +10279,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs0 => dimmconn-26/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs0 => dimmconn-26/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
-		<source_target>ddr_ch7:cs0</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
+		<source_target>ddr_ch4:cs0</source_target>
 		<dest_path>dimmconn-26/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10500,11 +10292,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs1 => dimmconn-27/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/ddr_ch4:cs1 => dimmconn-27/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
-		<source_target>ddr_ch7:cs1</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca4/</source_path>
+		<source_target>ddr_ch4:cs1</source_target>
 		<dest_path>dimmconn-27/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10513,11 +10305,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs1 => dimmconn-28/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs1 => dimmconn-28/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
-		<source_target>ddr_ch1:cs1</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
+		<source_target>ddr_ch0:cs1</source_target>
 		<dest_path>dimmconn-28/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10526,11 +10318,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs0 => dimmconn-29/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/ddr_ch0:cs0 => dimmconn-29/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
-		<source_target>ddr_ch1:cs0</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca0/</source_path>
+		<source_target>ddr_ch0:cs0</source_target>
 		<dest_path>dimmconn-29/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10539,11 +10331,11 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs1 => dimmconn-30/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs1 => dimmconn-30/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
-		<source_target>ddr_ch3:cs1</source_target>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
+		<source_target>ddr_ch2:cs1</source_target>
 		<dest_path>dimmconn-30/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
@@ -10552,12 +10344,220 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs0 => dimmconn-31/dimm-0/ddr4</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/ddr_ch2:cs0 => dimmconn-31/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca2/</source_path>
+		<source_target>ddr_ch2:cs0</source_target>
+		<dest_path>dimmconn-31/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs0 => dimmconn-0/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
+		<source_target>ddr_ch5:cs0</source_target>
+		<dest_path>dimmconn-0/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs1 => dimmconn-1/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
+		<source_target>ddr_ch5:cs1</source_target>
+		<dest_path>dimmconn-1/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs0 => dimmconn-2/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
+		<source_target>ddr_ch7:cs0</source_target>
+		<dest_path>dimmconn-2/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs1 => dimmconn-3/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
+		<source_target>ddr_ch7:cs1</source_target>
+		<dest_path>dimmconn-3/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs1 => dimmconn-4/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
+		<source_target>ddr_ch1:cs1</source_target>
+		<dest_path>dimmconn-4/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs0 => dimmconn-5/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
+		<source_target>ddr_ch1:cs0</source_target>
+		<dest_path>dimmconn-5/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs1 => dimmconn-6/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
+		<source_target>ddr_ch3:cs1</source_target>
+		<dest_path>dimmconn-6/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs0 => dimmconn-7/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
+		<source_target>ddr_ch3:cs0</source_target>
+		<dest_path>dimmconn-7/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs0 => dimmconn-8/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
+		<source_target>ddr_ch5:cs0</source_target>
+		<dest_path>dimmconn-8/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/ddr_ch5:cs1 => dimmconn-9/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs2/mca5/</source_path>
+		<source_target>ddr_ch5:cs1</source_target>
+		<dest_path>dimmconn-9/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs0 => dimmconn-10/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
+		<source_target>ddr_ch7:cs0</source_target>
+		<dest_path>dimmconn-10/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/ddr_ch7:cs1 => dimmconn-11/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist1/mcs3/mca7/</source_path>
+		<source_target>ddr_ch7:cs1</source_target>
+		<dest_path>dimmconn-11/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs1 => dimmconn-12/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
+		<source_target>ddr_ch1:cs1</source_target>
+		<dest_path>dimmconn-12/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/ddr_ch1:cs0 => dimmconn-13/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs0/mca1/</source_path>
+		<source_target>ddr_ch1:cs0</source_target>
+		<dest_path>dimmconn-13/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs1 => dimmconn-14/dimm-0/ddr4</bus_id>
+		<bus_type>DDR4</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
+		<source_target>ddr_ch3:cs1</source_target>
+		<dest_path>dimmconn-14/dimm-0/</dest_path>
+		<dest_target>ddr4</dest_target>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/ddr_ch3:cs0 => dimmconn-15/dimm-0/ddr4</bus_id>
 		<bus_type>DDR4</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/mcbist0/mcs1/mca3/</source_path>
 		<source_target>ddr_ch3:cs0</source_target>
-		<dest_path>dimmconn-31/dimm-0/</dest_path>
+		<dest_path>dimmconn-15/dimm-0/</dest_path>
 		<dest_target>ddr4</dest_target>
 		<bus_attribute>
 			<id>CLASS</id>
@@ -10588,342 +10588,6 @@
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-lightpath</source_target>
 		<dest_path>planar_vpd-0/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-0/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-0/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-1/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-1/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-2/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-2/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-3/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-3/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-4/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-4/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-5/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-5/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-6/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-6/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-7/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-7/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-8/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-8/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-9/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-9/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-10/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-10/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-11/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-11/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-12/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-12/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-13/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-13/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-14/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-14/dimm-0/spd/</dest_path>
-		<dest_target>i2c-slave</dest_target>
-		<bus_attribute>
-			<id>BUS_WIDTH</id>
-		<default>2</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>CLASS</id>
-		<default>BUS</default>
-		</bus_attribute>
-		<bus_attribute>
-			<id>I2C_SPEED</id>
-		<default>400</default>
-		</bus_attribute>
-	</bus>
-	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-15/dimm-0/spd/i2c-slave</bus_id>
-		<bus_type>I2C</bus_type>
-		<cable>no</cable>
-		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
-		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-15/dimm-0/spd/</dest_path>
 		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -11275,13 +10939,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-0/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-0/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-0/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-0/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11296,13 +10960,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-1/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-1/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-1/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-1/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11317,13 +10981,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-2/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-2/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-2/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-2/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11338,13 +11002,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-3/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-3/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-3/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-3/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11359,13 +11023,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-4/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-4/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-4/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-4/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11380,13 +11044,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-5/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-5/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-5/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-5/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11401,13 +11065,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-6/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-6/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-6/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-6/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11422,13 +11086,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-7/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-7/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-7/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-7/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11443,13 +11107,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-8/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-8/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-8/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-8/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11464,13 +11128,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-9/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-9/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-9/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-9/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11485,13 +11149,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-10/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-10/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-10/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-10/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11506,13 +11170,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-11/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-11/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm4567</source_target>
-		<dest_path>dimmconn-11/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-11/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11527,13 +11191,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-12/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-12/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-12/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-12/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11548,13 +11212,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-13/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-13/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-13/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-13/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11569,13 +11233,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-14/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-14/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-14/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-14/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11590,13 +11254,13 @@
 		</bus_attribute>
 	</bus>
 	<bus>
-		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-15/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-15/dimm-0/spd/i2c-slave</bus_id>
 		<bus_type>I2C</bus_type>
 		<cable>no</cable>
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
-		<dest_path>dimmconn-15/dimm-0/dimm-thermal-sensor/</dest_path>
-		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<dest_path>dimmconn-15/dimm-0/spd/</dest_path>
+		<dest_target>i2c-slave</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
 		<default>2</default>
@@ -11932,6 +11596,342 @@
 		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
 		<source_target>i2c-master-dimm0123</source_target>
 		<dest_path>dimmconn-31/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-0/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-0/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-1/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-1/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-2/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-2/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-3/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-3/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-4/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-4/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-5/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-5/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-6/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-6/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-0/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-7/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-0/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-7/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-8/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-8/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-9/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-9/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-10/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-10/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm4567 => dimmconn-11/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm4567</source_target>
+		<dest_path>dimmconn-11/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-12/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-12/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-13/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-13/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-14/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-14/dimm-0/dimm-thermal-sensor/</dest_path>
+		<dest_target>dimm-thermal-sensor.i2c</dest_target>
+		<bus_attribute>
+			<id>BUS_WIDTH</id>
+		<default>2</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>CLASS</id>
+		<default>BUS</default>
+		</bus_attribute>
+		<bus_attribute>
+			<id>I2C_SPEED</id>
+		<default>400</default>
+		</bus_attribute>
+	</bus>
+	<bus>
+		<bus_id>proc_socket-1/module-0/p9_proc_l/i2c-master-dimm0123 => dimmconn-15/dimm-0/dimm-thermal-sensor/dimm-thermal-sensor.i2c</bus_id>
+		<bus_type>I2C</bus_type>
+		<cable>no</cable>
+		<source_path>proc_socket-1/module-0/p9_proc_l/</source_path>
+		<source_target>i2c-master-dimm0123</source_target>
+		<dest_path>dimmconn-15/dimm-0/dimm-thermal-sensor/</dest_path>
 		<dest_target>dimm-thermal-sensor.i2c</dest_target>
 		<bus_attribute>
 			<id>BUS_WIDTH</id>
@@ -130736,11 +130736,11 @@
 	</attribute>
 </targetInstance>
 <targetInstance>
-	<id>dimmconn-0</id>
+	<id>dimmconn-16</id>
 	<type>connector-dimmconn-ddr4</type>
 	<is_root>false</is_root>
 	<instance_name>dimmconn</instance_name>
-	<position>0</position>
+	<position>16</position>
 	<child_id>dimm-0</child_id>
 	<attribute>
 		<id>AFFINITY_PATH</id>
@@ -130819,7 +130819,7 @@
 	</attribute>
 	<attribute>
 		<id>POSITION</id>
-		<default>0</default>
+		<default>16</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>
@@ -131834,1670 +131834,6 @@
 	<attribute>
 		<id>REL_POS</id>
 		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-1</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>1</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>1</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-2</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>2</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>2</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-3</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>3</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>3</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-4</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>4</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>4</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-5</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>5</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>5</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-6</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>6</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>6</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-7</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>7</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>7</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-8</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>8</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>8</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-9</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>9</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>9</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-10</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>10</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>10</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-11</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>11</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>11</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-12</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>12</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>12</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-13</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>13</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>13</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-14</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>14</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>14</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-15</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>15</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>15</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>RESOURCE_IS_CRITICAL</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>TYPE</id>
-		<default>NA</default>
-	</attribute>
-</targetInstance>
-<targetInstance>
-	<id>dimmconn-16</id>
-	<type>connector-dimmconn-ddr4</type>
-	<is_root>false</is_root>
-	<instance_name>dimmconn</instance_name>
-	<position>16</position>
-	<child_id>dimm-0</child_id>
-	<attribute>
-		<id>AFFINITY_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>CLASS</id>
-		<default>CONNECTOR</default>
-	</attribute>
-	<attribute>
-		<id>CONNECTOR_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>DECONFIG_GARDABLE</id>
-		<default>0</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_NAME</id>
-		<default>unknown</default>
-	</attribute>
-	<attribute>
-		<id>FAPI_POS</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>HUID</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE</id>
-		<default>
-				<field><id>deconfiguredByEid</id><value></value></field>
-				<field><id>poweredOn</id><value></value></field>
-				<field><id>present</id><value></value></field>
-				<field><id>functional</id><value></value></field>
-				<field><id>dumpfunctional</id><value></value></field>
-				<field><id>specdeconfig</id><value></value></field>
-		</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_FLAG</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
-		<default>0x0</default>
-	</attribute>
-	<attribute>
-		<id>IPMI_INSTANCE</id>
-		<default>0xFF</default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>LOCATION_CODE_TYPE</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>MODEL</id>
-		<default>JEDEC</default>
-	</attribute>
-	<attribute>
-		<id>MRW_TYPE</id>
-		<default>NA</default>
-	</attribute>
-	<attribute>
-		<id>ORDINAL_ID</id>
-		<default>0xFFFFFFFF</default>
-	</attribute>
-	<attribute>
-		<id>PHYS_PATH</id>
-		<default></default>
-	</attribute>
-	<attribute>
-		<id>POSITION</id>
-		<default>16</default>
-	</attribute>
-	<attribute>
-		<id>PRIMARY_CAPABILITIES</id>
-		<default>
-				<field><id>supportsFsiScom</id><value></value></field>
-				<field><id>supportsXscom</id><value></value></field>
-				<field><id>supportsInbandScom</id><value></value></field>
-				<field><id>reserved</id><value></value></field>
-		</default>
 	</attribute>
 	<attribute>
 		<id>RESOURCE_IS_CRITICAL</id>
@@ -135049,6 +133385,1670 @@
 	<attribute>
 		<id>POSITION</id>
 		<default>31</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-0</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>0</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-1</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>1</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>1</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-2</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>2</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>2</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-3</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>3</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>3</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-4</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>4</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>4</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-5</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>5</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>5</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-6</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>6</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>6</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-7</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>7</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>7</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-8</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>8</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>8</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-9</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>9</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>9</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-10</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>10</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>10</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-11</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>11</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>11</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-12</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>12</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>12</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-13</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>13</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>13</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-14</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>14</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>14</default>
+	</attribute>
+	<attribute>
+		<id>PRIMARY_CAPABILITIES</id>
+		<default>
+				<field><id>supportsFsiScom</id><value></value></field>
+				<field><id>supportsXscom</id><value></value></field>
+				<field><id>supportsInbandScom</id><value></value></field>
+				<field><id>reserved</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>RESOURCE_IS_CRITICAL</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>TYPE</id>
+		<default>NA</default>
+	</attribute>
+</targetInstance>
+<targetInstance>
+	<id>dimmconn-15</id>
+	<type>connector-dimmconn-ddr4</type>
+	<is_root>false</is_root>
+	<instance_name>dimmconn</instance_name>
+	<position>15</position>
+	<child_id>dimm-0</child_id>
+	<attribute>
+		<id>AFFINITY_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>CLASS</id>
+		<default>CONNECTOR</default>
+	</attribute>
+	<attribute>
+		<id>CONNECTOR_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>DECONFIG_GARDABLE</id>
+		<default>0</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_NAME</id>
+		<default>unknown</default>
+	</attribute>
+	<attribute>
+		<id>FAPI_POS</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>HUID</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE</id>
+		<default>
+				<field><id>deconfiguredByEid</id><value></value></field>
+				<field><id>poweredOn</id><value></value></field>
+				<field><id>present</id><value></value></field>
+				<field><id>functional</id><value></value></field>
+				<field><id>dumpfunctional</id><value></value></field>
+				<field><id>specdeconfig</id><value></value></field>
+		</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_FLAG</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>HWAS_STATE_CHANGED_SUBSCRIPTION_MASK</id>
+		<default>0x0</default>
+	</attribute>
+	<attribute>
+		<id>IPMI_INSTANCE</id>
+		<default>0xFF</default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>LOCATION_CODE_TYPE</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>MODEL</id>
+		<default>JEDEC</default>
+	</attribute>
+	<attribute>
+		<id>MRW_TYPE</id>
+		<default>NA</default>
+	</attribute>
+	<attribute>
+		<id>ORDINAL_ID</id>
+		<default>0xFFFFFFFF</default>
+	</attribute>
+	<attribute>
+		<id>PHYS_PATH</id>
+		<default></default>
+	</attribute>
+	<attribute>
+		<id>POSITION</id>
+		<default>15</default>
 	</attribute>
 	<attribute>
 		<id>PRIMARY_CAPABILITIES</id>


### PR DESCRIPTION
DVT board is switching ordering such that DIMMs 0-15 are in the front and DIMMs 16-31 are in the back.